### PR TITLE
I added an 'exclude type' hidden option.

### DIFF
--- a/hoenn_dex.html
+++ b/hoenn_dex.html
@@ -12,9 +12,9 @@
     </style>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script>
-        $(window).on('load', function () {
-            $("#loader").fadeOut("slow");
-        });
+      $(window).on('load', function () {
+        $("#loader").fadeOut("slow");
+      });
     </script>
 </head>
 
@@ -86,237 +86,289 @@
             <table id="team-weaknesses">
                 <caption>This Team Is Weak Against</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
             <table id="team-immunities">
                 <caption>This Team Is Immune To</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
             <table id="team-resistances">
                 <caption>This Team Resists</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
         </div>
         <div id="copy-url">
-            <p>Click the "Copy" button to copy your team's URL to your clipboard and share it with your friends and neighbors!</p>
+            <p>Click the "Copy" button to copy your team's URL to your clipboard and share it with your friends and
+                neighbors!</p>
             <input type="text" readonly><!--
             --><a data-clipboard-target="#copy-url input">Copy</a>
         </div>
@@ -325,18 +377,65 @@
         <h2>Your Options</h2>
         <div id="filters">
             <h3>Filters</h3><!--
-            --><div class="filter">
+            -->
+            <div class="filter">
                 <label for="gen-filter">Generation</label><!--
                 --><select id="gen-filter" multiple>
-                    <option value="gen1">Generation I</option>
-                    <option value="gen2">Generation II</option>
-                    <option value="gen3">Generation III</option>
-                    <option value="gen4">Generation IV</option>
-                </select>
+                <option value="gen1">Generation I</option>
+                <option value="gen2">Generation II</option>
+                <option value="gen3">Generation III</option>
+                <option value="gen4">Generation IV</option>
+            </select>
             </div><!--
-            --><div class="filter">
+            -->
+            <div class="filter">
                 <label for="type-filter">Type</label><!--
                 --><select id="type-filter" multiple>
+                <option value="normal">Normal</option>
+                <option value="grass">Grass</option>
+                <option value="fire">Fire</option>
+                <option value="water">Water</option>
+                <option value="fighting">Fighting</option>
+                <option value="flying">Flying</option>
+                <option value="poison">Poison</option>
+                <option value="ground">Ground</option>
+                <option value="rock">Rock</option>
+                <option value="bug">Bug</option>
+                <option value="ghost">Ghost</option>
+                <option value="electric">Electric</option>
+                <option value="psychic">Psychic</option>
+                <option value="ice">Ice</option>
+                <option value="dragon">Dragon</option>
+                <option value="dark">Dark</option>
+                <option value="steel">Steel</option>
+                <option value="fairy">Fairy</option>
+            </select>
+            </div><!--
+            -->
+            <div class="filter">
+                <label for="evolution-filter">Evolution</label><!--
+                --><select id="evolution-filter" multiple>
+                <option value="nfe">Not Fully Evolved</option>
+                <option value="fe">Fully Evolved</option>
+                <option value="mega">Mega Evolved</option>
+            </select>
+            </div><!--
+            --><a href="#" class="button" title="Show more filters">+</a><!--
+            --><a href="#" class="button hidden" title="Hide extra filters">−</a><!--
+            -->
+            <div class="more">
+                <div class="filter hidden">
+                    <label for="version-filter">Version</label><!--
+                    --><select id="version-filter" multiple>
+                    <option value="ruby">Omega Ruby</option>
+                    <option value="sapphire">Alpha Sapphire</option>
+                    <option value="both">Both</option>
+                </select>
+                </div><!--
+                -->
+                <div class="filter hidden">
+                    <label for="resistance-filter">Resists</label><!--
+                    --><select id="resistance-filter" multiple>
                     <option value="normal">Normal</option>
                     <option value="grass">Grass</option>
                     <option value="fire">Fire</option>
@@ -356,29 +455,10 @@
                     <option value="steel">Steel</option>
                     <option value="fairy">Fairy</option>
                 </select>
-            </div><!--
-            --><div class="filter">
-                <label for="evolution-filter">Evolution</label><!--
-                --><select id="evolution-filter" multiple>
-                    <option value="nfe">Not Fully Evolved</option>
-                    <option value="fe">Fully Evolved</option>
-                    <option value="mega">Mega Evolved</option>
-                </select>
-            </div><!--
-            --><a href="#" class="button" title="Show more filters">+</a><!--
-            --><a href="#" class="button hidden" title="Hide extra filters">−</a><!--
-            --><div class="more">
+                </div>
                 <div class="filter hidden">
-                    <label for="version-filter">Version</label><!--
-                    --><select id="version-filter" multiple>
-                        <option value="ruby">Omega Ruby</option>
-                        <option value="sapphire">Alpha Sapphire</option>
-                        <option value="both">Both</option>
-                    </select>
-                </div><!--
-                --><div class="filter hidden">
-                    <label for="resistance-filter">Resists</label><!--
-                    --><select id="resistance-filter" multiple>
+                    <label for="exclude-type-filter">Exclude Type</label>
+                    <select id="exclude-type-filter" multiple>
                         <option value="normal">Normal</option>
                         <option value="grass">Grass</option>
                         <option value="fire">Fire</option>
@@ -398,9 +478,10 @@
                         <option value="steel">Steel</option>
                         <option value="fairy">Fairy</option>
                     </select>
-                </div><!--
-                --><div class="filter hidden">
-                    <label for="search-bar">Search</label><input id="search-bar" type="search" placeholder="by Pokémon name">
+                </div>
+                <div class="filter hidden">
+                    <label for="search-bar">Search</label><input id="search-bar" type="search"
+                                                                 placeholder="by Pokémon name">
                 </div>
             </div>
         </div>
@@ -649,14 +730,36 @@
         </ol>
     </section>
     <footer>
-        <p class="links">Looking for another dex? Check out the planners for the <a href="national_dex.html">National</a>, <a href="kalos_dex.html">Kalos</a>, <a href="old_alola_dex.html">Old Alola</a>, and <a href="/pokemon-team-planner/">New Alola</a> dexes.</p>
-        <p>Please report bugs or leave feedback in <a href="http://www.smogon.com/forums/threads/team-planner-for-pok%C3%A9mon-sun-moon.3585346/">this thread</a>.</p>
+        <p class="links">Looking for another dex? Check out the planners for the <a
+                href="national_dex.html">National</a>, <a href="kalos_dex.html">Kalos</a>, <a href="old_alola_dex.html">Old
+            Alola</a>, and <a href="/pokemon-team-planner/">New Alola</a> dexes.</p>
+        <p>Please report bugs or leave feedback in <a
+                href="http://www.smogon.com/forums/threads/team-planner-for-pok%C3%A9mon-sun-moon.3585346/">this
+            thread</a>.</p>
         <p>
-            © of <a href="http://twitter.com/richi3f">richi3f</a>, <time datetime="2016">2016</time>-<time datetime="2017">2017</time><br>
-            Bootstrap is © of Twitter, <time datetime="2016">2016</time><br>
-            <a href="http://davidstutz.github.io/bootstrap-multiselect/">Bootstrap Multiselect</a> is © of <a href="http://davidstutz.de/">David Stutz</a>, <time datetime="2012">2012</time>-<time datetime="2014">2014</time><br>
-            <a href="https://clipboardjs.com">Clipboard.js</a> is © of <a href="http://zenorocha.com">Zeno Rocha</a>, <time datetime="2015">2015</time>-<time datetime="2017">2017</time><br>
-            Pokémon is © of Nintendo, <time datetime="1995">1995</time>-<time datetime="2017">2017</time>
+            © of <a href="http://twitter.com/richi3f">richi3f</a>,
+            <time datetime="2016">2016</time>
+            -
+            <time datetime="2017">2017</time>
+            <br>
+            Bootstrap is © of Twitter,
+            <time datetime="2016">2016</time>
+            <br>
+            <a href="http://davidstutz.github.io/bootstrap-multiselect/">Bootstrap Multiselect</a> is © of <a
+                href="http://davidstutz.de/">David Stutz</a>,
+            <time datetime="2012">2012</time>
+            -
+            <time datetime="2014">2014</time>
+            <br>
+            <a href="https://clipboardjs.com">Clipboard.js</a> is © of <a href="http://zenorocha.com">Zeno Rocha</a>,
+            <time datetime="2015">2015</time>
+            -
+            <time datetime="2017">2017</time>
+            <br>
+            Pokémon is © of Nintendo,
+            <time datetime="1995">1995</time>
+            -
+            <time datetime="2017">2017</time>
         </p>
     </footer>
 </article>

--- a/kalos_dex.html
+++ b/kalos_dex.html
@@ -12,9 +12,9 @@
     </style>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script>
-        $(window).on('load', function () {
-            $("#loader").fadeOut("slow");
-        });
+      $(window).on('load', function () {
+        $("#loader").fadeOut("slow");
+      });
     </script>
 </head>
 
@@ -86,237 +86,289 @@
             <table id="team-weaknesses">
                 <caption>This Team Is Weak Against</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
             <table id="team-immunities">
                 <caption>This Team Is Immune To</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
             <table id="team-resistances">
                 <caption>This Team Resists</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
         </div>
         <div id="copy-url">
-            <p>Click the "Copy" button to copy your team's URL to your clipboard and share it with your friends and neighbors!</p>
+            <p>Click the "Copy" button to copy your team's URL to your clipboard and share it with your friends and
+                neighbors!</p>
             <input type="text" readonly><!--
             --><a data-clipboard-target="#copy-url input">Copy</a>
         </div>
@@ -325,29 +377,68 @@
         <h2>Your Options</h2>
         <div id="filters">
             <h3>Filters</h3><!--
-            --><div class="filter">
+            -->
+            <div class="filter">
                 <label for="area-filter">Area</label><!--
                 --><select id="area-filter" multiple>
-                    <option value="central">Central</option>
-                    <option value="coastal">Coastal</option>
-                    <option value="mountain">Mountain</option>
-                </select>
+                <option value="central">Central</option>
+                <option value="coastal">Coastal</option>
+                <option value="mountain">Mountain</option>
+            </select>
             </div><!--
-            --><div class="filter">
+            -->
+            <div class="filter">
                 <label for="gen-filter">Generation</label><!--
                 --><select id="gen-filter" multiple>
-                    <option value="gen1">Generation I</option>
-                    <option value="gen2">Generation II</option>
-                    <option value="gen3">Generation III</option>
-                    <option value="gen4">Generation IV</option>
-                    <option value="gen5">Generation V</option>
-                    <option value="gen6">Generation VI</option>
-                    <option value="gen7">Generation VII</option>
-                </select>
+                <option value="gen1">Generation I</option>
+                <option value="gen2">Generation II</option>
+                <option value="gen3">Generation III</option>
+                <option value="gen4">Generation IV</option>
+                <option value="gen5">Generation V</option>
+                <option value="gen6">Generation VI</option>
+                <option value="gen7">Generation VII</option>
+            </select>
             </div><!--
-            --><div class="filter">
+            -->
+            <div class="filter">
                 <label for="type-filter">Type</label><!--
                 --><select id="type-filter" multiple>
+                <option value="normal">Normal</option>
+                <option value="grass">Grass</option>
+                <option value="fire">Fire</option>
+                <option value="water">Water</option>
+                <option value="fighting">Fighting</option>
+                <option value="flying">Flying</option>
+                <option value="poison">Poison</option>
+                <option value="ground">Ground</option>
+                <option value="rock">Rock</option>
+                <option value="bug">Bug</option>
+                <option value="ghost">Ghost</option>
+                <option value="electric">Electric</option>
+                <option value="psychic">Psychic</option>
+                <option value="ice">Ice</option>
+                <option value="dragon">Dragon</option>
+                <option value="dark">Dark</option>
+                <option value="steel">Steel</option>
+                <option value="fairy">Fairy</option>
+            </select>
+            </div><!--
+            --><a href="#" class="button" title="Show more filters">+</a><!--
+            --><a href="#" class="button hidden" title="Hide extra filters">−</a><!--
+            -->
+            <div class="more">
+                <div class="filter hidden">
+                    <label for="version-filter">Version</label><!--
+                    --><select id="version-filter" multiple>
+                    <option value="x">X</option>
+                    <option value="y">Y</option>
+                    <option value="both">Both</option>
+                </select>
+                </div><!--
+                -->
+                <div class="filter hidden">
+                    <label for="resistance-filter">Resists</label><!--
+                    --><select id="resistance-filter" multiple>
                     <option value="normal">Normal</option>
                     <option value="grass">Grass</option>
                     <option value="fire">Fire</option>
@@ -367,21 +458,10 @@
                     <option value="steel">Steel</option>
                     <option value="fairy">Fairy</option>
                 </select>
-            </div><!--
-            --><a href="#" class="button" title="Show more filters">+</a><!--
-            --><a href="#" class="button hidden" title="Hide extra filters">−</a><!--
-            --><div class="more">
+                </div>
                 <div class="filter hidden">
-                    <label for="version-filter">Version</label><!--
-                    --><select id="version-filter" multiple>
-                        <option value="x">X</option>
-                        <option value="y">Y</option>
-                        <option value="both">Both</option>
-                    </select>
-                </div><!--
-                --><div class="filter hidden">
-                    <label for="resistance-filter">Resists</label><!--
-                    --><select id="resistance-filter" multiple>
+                    <label for="exclude-type-filter">Exclude Type</label>
+                    <select id="exclude-type-filter" multiple>
                         <option value="normal">Normal</option>
                         <option value="grass">Grass</option>
                         <option value="fire">Fire</option>
@@ -401,17 +481,19 @@
                         <option value="steel">Steel</option>
                         <option value="fairy">Fairy</option>
                     </select>
-                </div><!--
-                --><div class="filter hidden">
+                </div>
+                <div class="filter hidden">
                     <label for="evolution-filter">Evolution</label><!--
                     --><select id="evolution-filter" multiple>
-                        <option value="nfe">Not Fully Evolved</option>
-                        <option value="fe">Fully Evolved</option>
-                        <option value="mega">Mega Evolved</option>
-                    </select>
+                    <option value="nfe">Not Fully Evolved</option>
+                    <option value="fe">Fully Evolved</option>
+                    <option value="mega">Mega Evolved</option>
+                </select>
                 </div><!--
-                --><div class="filter hidden">
-                    <label for="search-bar">Search</label><input id="search-bar" type="search" placeholder="by Pokémon name">
+                -->
+                <div class="filter hidden">
+                    <label for="search-bar">Search</label><input id="search-bar" type="search"
+                                                                 placeholder="by Pokémon name">
                 </div>
             </div>
         </div>
@@ -510,8 +592,10 @@
             <li class="gen1 central nfe fire1"><a href="#" class="menu-sprite charmander">Charmander</a>
             <li class="gen1 central nfe fire1"><a href="#" class="menu-sprite charmeleon">Charmeleon</a>
             <li class="gen1 central fire1 flying2"><a href="#" class="menu-sprite charizard">Charizard</a>
-            <li class="gen1 central x fire1 dragon2"><a href="#" class="menu-sprite charizard-mega-x">Mega Charizard X</a>
-            <li class="gen1 central y fire1 flying2"><a href="#" class="menu-sprite charizard-mega-y">Mega Charizard Y</a>
+            <li class="gen1 central x fire1 dragon2"><a href="#" class="menu-sprite charizard-mega-x">Mega Charizard
+                X</a>
+            <li class="gen1 central y fire1 flying2"><a href="#" class="menu-sprite charizard-mega-y">Mega Charizard
+                Y</a>
             <li class="gen1 central nfe water1"><a href="#" class="menu-sprite squirtle">Squirtle</a>
             <li class="gen1 central nfe water1"><a href="#" class="menu-sprite wartortle">Wartortle</a>
             <li class="gen1 central water1"><a href="#" class="menu-sprite blastoise">Blastoise</a>
@@ -906,19 +990,42 @@
             <li class="gen6 mountain y dark1 flying2"><a href="#" class="menu-sprite yveltal">Yveltal</a>
             <li class="gen6 mountain dragon1 ground2"><a href="#" class="menu-sprite zygarde">Zygarde</a>
             <li class="gen1 mountain psychic1"><a href="#" class="menu-sprite mewtwo">Mewtwo</a>
-            <li class="gen1 mountain x psychic1 fighting2"><a href="#" class="menu-sprite mewtwo-mega-x">Mega Mewtwo X</a>
+            <li class="gen1 mountain x psychic1 fighting2"><a href="#" class="menu-sprite mewtwo-mega-x">Mega Mewtwo
+                X</a>
             <li class="gen1 mountain y psychic1"><a href="#" class="menu-sprite mewtwo-mega-y">Mega Mewtwo Y</a>
         </ol>
     </section>
     <footer>
-        <p class="links">Looking for another dex? Check out the planners for the <a href="national_dex.html">National</a>, <a href="hoenn_dex.html">Hoenn</a>, <a href="old_alola_dex.html">Old Alola</a>, and <a href="/pokemon-team-planner/">New Alola</a> dexes.</p>
-        <p>Please report bugs or leave feedback in <a href="http://www.smogon.com/forums/threads/team-planner-for-pok%C3%A9mon-sun-moon.3585346/">this thread</a>.</p>
+        <p class="links">Looking for another dex? Check out the planners for the <a
+                href="national_dex.html">National</a>, <a href="hoenn_dex.html">Hoenn</a>, <a href="old_alola_dex.html">Old
+            Alola</a>, and <a href="/pokemon-team-planner/">New Alola</a> dexes.</p>
+        <p>Please report bugs or leave feedback in <a
+                href="http://www.smogon.com/forums/threads/team-planner-for-pok%C3%A9mon-sun-moon.3585346/">this
+            thread</a>.</p>
         <p>
-            © of <a href="http://twitter.com/richi3f">richi3f</a>, <time datetime="2016">2016</time>-<time datetime="2017">2017</time><br>
-            Bootstrap is © of Twitter, <time datetime="2016">2016</time><br>
-            <a href="http://davidstutz.github.io/bootstrap-multiselect/">Bootstrap Multiselect</a> is © of <a href="http://davidstutz.de/">David Stutz</a>, <time datetime="2012">2012</time>-<time datetime="2014">2014</time><br>
-            <a href="https://clipboardjs.com">Clipboard.js</a> is © of <a href="http://zenorocha.com">Zeno Rocha</a>, <time datetime="2015">2015</time>-<time datetime="2017">2017</time><br>
-            Pokémon is © of Nintendo, <time datetime="1995">1995</time>-<time datetime="2017">2017</time>
+            © of <a href="http://twitter.com/richi3f">richi3f</a>,
+            <time datetime="2016">2016</time>
+            -
+            <time datetime="2017">2017</time>
+            <br>
+            Bootstrap is © of Twitter,
+            <time datetime="2016">2016</time>
+            <br>
+            <a href="http://davidstutz.github.io/bootstrap-multiselect/">Bootstrap Multiselect</a> is © of <a
+                href="http://davidstutz.de/">David Stutz</a>,
+            <time datetime="2012">2012</time>
+            -
+            <time datetime="2014">2014</time>
+            <br>
+            <a href="https://clipboardjs.com">Clipboard.js</a> is © of <a href="http://zenorocha.com">Zeno Rocha</a>,
+            <time datetime="2015">2015</time>
+            -
+            <time datetime="2017">2017</time>
+            <br>
+            Pokémon is © of Nintendo,
+            <time datetime="1995">1995</time>
+            -
+            <time datetime="2017">2017</time>
         </p>
     </footer>
 </article>

--- a/national_dex.html
+++ b/national_dex.html
@@ -12,9 +12,9 @@
     </style>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script>
-        $(window).on('load', function () {
-            $("#loader").fadeOut("slow");
-        });
+      $(window).on('load', function () {
+        $("#loader").fadeOut("slow");
+      });
     </script>
 </head>
 
@@ -86,237 +86,289 @@
             <table id="team-weaknesses">
                 <caption>This Team Is Weak Against</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
             <table id="team-immunities">
                 <caption>This Team Is Immune To</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
             <table id="team-resistances">
                 <caption>This Team Resists</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
         </div>
         <div id="copy-url">
-            <p>Click the "Copy" button to copy your team's URL to your clipboard and share it with your friends and neighbors!</p>
+            <p>Click the "Copy" button to copy your team's URL to your clipboard and share it with your friends and
+                neighbors!</p>
             <input type="text" readonly><!--
             --><a data-clipboard-target="#copy-url input">Copy</a>
         </div>
@@ -325,21 +377,59 @@
         <h2>Your Options</h2>
         <div id="filters">
             <h3>Filters</h3><!--
-            --><div class="filter">
+            -->
+            <div class="filter">
                 <label for="gen-filter">Generation</label><!--
                 --><select id="gen-filter" multiple>
-                    <option value="gen1">Generation I</option>
-                    <option value="gen2">Generation II</option>
-                    <option value="gen3">Generation III</option>
-                    <option value="gen4">Generation IV</option>
-                    <option value="gen5">Generation V</option>
-                    <option value="gen6">Generation VI</option>
-                    <option value="gen7">Generation VII</option>
-                </select>
+                <option value="gen1">Generation I</option>
+                <option value="gen2">Generation II</option>
+                <option value="gen3">Generation III</option>
+                <option value="gen4">Generation IV</option>
+                <option value="gen5">Generation V</option>
+                <option value="gen6">Generation VI</option>
+                <option value="gen7">Generation VII</option>
+            </select>
             </div><!--
-            --><div class="filter">
+            -->
+            <div class="filter">
                 <label for="type-filter">Type</label><!--
-                --><select id="type-filter" multiple>
+                --><select id="type-filter" class="exclusion" multiple>
+                <option value="normal">Normal</option>
+                <option value="grass">Grass</option>
+                <option value="fire">Fire</option>
+                <option value="water">Water</option>
+                <option value="fighting">Fighting</option>
+                <option value="flying">Flying</option>
+                <option value="poison">Poison</option>
+                <option value="ground">Ground</option>
+                <option value="rock">Rock</option>
+                <option value="bug">Bug</option>
+                <option value="ghost">Ghost</option>
+                <option value="electric">Electric</option>
+                <option value="psychic">Psychic</option>
+                <option value="ice">Ice</option>
+                <option value="dragon">Dragon</option>
+                <option value="dark">Dark</option>
+                <option value="steel">Steel</option>
+                <option value="fairy">Fairy</option>
+            </select>
+            </div><!--
+            -->
+            <div class="filter">
+                <label for="evolution-filter">Evolution</label><!--
+                --><select id="evolution-filter" multiple>
+                <option value="nfe">Not Fully Evolved</option>
+                <option value="fe">Fully Evolved</option>
+                <option value="mega">Mega Evolved</option>
+            </select>
+            </div><!--
+            --><a href="#" class="button" title="Show more filters">+</a><!--
+            --><a href="#" class="button hidden" title="Hide extra filters">−</a><!--
+            -->
+            <div class="more">
+                <div class="filter hidden">
+                    <label for="resistance-filter">Resists</label><!--
+                    --><select id="resistance-filter" multiple>
                     <option value="normal">Normal</option>
                     <option value="grass">Grass</option>
                     <option value="fire">Fire</option>
@@ -359,42 +449,32 @@
                     <option value="steel">Steel</option>
                     <option value="fairy">Fairy</option>
                 </select>
-            </div><!--
-            --><div class="filter">
-                <label for="evolution-filter">Evolution</label><!--
-                --><select id="evolution-filter" multiple>
-                    <option value="nfe">Not Fully Evolved</option>
-                    <option value="fe">Fully Evolved</option>
-                    <option value="mega">Mega Evolved</option>
-                </select>
-            </div><!--
-            --><a href="#" class="button" title="Show more filters">+</a><!--
-            --><a href="#" class="button hidden" title="Hide extra filters">−</a><!--
-            --><div class="more">
+                </div>
                 <div class="filter hidden">
-                    <label for="resistance-filter">Resists</label><!--
-                    --><select id="resistance-filter" multiple>
-                        <option value="normal">Normal</option>
-                        <option value="grass">Grass</option>
-                        <option value="fire">Fire</option>
-                        <option value="water">Water</option>
-                        <option value="fighting">Fighting</option>
-                        <option value="flying">Flying</option>
-                        <option value="poison">Poison</option>
-                        <option value="ground">Ground</option>
-                        <option value="rock">Rock</option>
-                        <option value="bug">Bug</option>
-                        <option value="ghost">Ghost</option>
-                        <option value="electric">Electric</option>
-                        <option value="psychic">Psychic</option>
-                        <option value="ice">Ice</option>
-                        <option value="dragon">Dragon</option>
-                        <option value="dark">Dark</option>
-                        <option value="steel">Steel</option>
-                        <option value="fairy">Fairy</option>
-                    </select>
+                    <label for="exclude-type-filter">Exclude Type</label><!--
+                --><select id="exclude-type-filter" multiple>
+                    <option value="normal">Normal</option>
+                    <option value="grass">Grass</option>
+                    <option value="fire">Fire</option>
+                    <option value="water">Water</option>
+                    <option value="fighting">Fighting</option>
+                    <option value="flying">Flying</option>
+                    <option value="poison">Poison</option>
+                    <option value="ground">Ground</option>
+                    <option value="rock">Rock</option>
+                    <option value="bug">Bug</option>
+                    <option value="ghost">Ghost</option>
+                    <option value="electric">Electric</option>
+                    <option value="psychic">Psychic</option>
+                    <option value="ice">Ice</option>
+                    <option value="dragon">Dragon</option>
+                    <option value="dark">Dark</option>
+                    <option value="steel">Steel</option>
+                    <option value="fairy">Fairy</option>
+                </select>
                 </div><!--
-                --><div class="filter hidden">
+                -->
+                <div class="filter hidden">
                     <label for="search-bar">Search</label><input id="search-bar" type="search">
                 </div>
             </div>
@@ -1350,15 +1430,38 @@
         </ol>
     </section>
     <footer>
-        <p class="links">Looking for another dex? Check out the planners for the <a href="kalos_dex.html">Kalos</a>, <a href="hoenn_dex.html">Hoenn</a>, <a href="old_alola_dex.html">Old Alola</a>, and <a href="/pokemon-team-planner/">New Alola</a> dexes.</p>
-        <p>Please report bugs or leave feedback in <a href="http://www.smogon.com/forums/threads/team-planner-for-pok%C3%A9mon-sun-moon.3585346/">this thread</a>.</p>
+        <p class="links">Looking for another dex? Check out the planners for the <a href="kalos_dex.html">Kalos</a>, <a
+                href="hoenn_dex.html">Hoenn</a>, <a href="old_alola_dex.html">Old Alola</a>, and <a
+                href="/pokemon-team-planner/">New Alola</a> dexes.</p>
+        <p>Please report bugs or leave feedback in <a
+                href="http://www.smogon.com/forums/threads/team-planner-for-pok%C3%A9mon-sun-moon.3585346/">this
+            thread</a>.</p>
         <p>
-            © of <a href="http://twitter.com/richi3f">richi3f</a>, <time datetime="2016">2016</time>-<time datetime="2017">2017</time><br>
-            Bootstrap is © of Twitter, <time datetime="2016">2016</time><br>
-            <a href="http://davidstutz.github.io/bootstrap-multiselect/">Bootstrap Multiselect</a> is © of <a href="http://davidstutz.de/">David Stutz</a>, <time datetime="2012">2012</time>-<time datetime="2014">2014</time><br>
-            <a href="https://clipboardjs.com">Clipboard.js</a> is © of <a href="http://zenorocha.com">Zeno Rocha</a>, <time datetime="2015">2015</time>-<time datetime="2017">2017</time><br>
-            Pokémon icons, names and typings datamined by Kaphotics, SciresM, Marty, smealum, Bond697, Slashmolder &amp; Normmatt<br>
-            Pokémon is © of Nintendo, <time datetime="1995">1995</time>-<time datetime="2017">2017</time>
+            © of <a href="http://twitter.com/richi3f">richi3f</a>,
+            <time datetime="2016">2016</time>
+            -
+            <time datetime="2017">2017</time>
+            <br>
+            Bootstrap is © of Twitter,
+            <time datetime="2016">2016</time>
+            <br>
+            <a href="http://davidstutz.github.io/bootstrap-multiselect/">Bootstrap Multiselect</a> is © of <a
+                href="http://davidstutz.de/">David Stutz</a>,
+            <time datetime="2012">2012</time>
+            -
+            <time datetime="2014">2014</time>
+            <br>
+            <a href="https://clipboardjs.com">Clipboard.js</a> is © of <a href="http://zenorocha.com">Zeno Rocha</a>,
+            <time datetime="2015">2015</time>
+            -
+            <time datetime="2017">2017</time>
+            <br>
+            Pokémon icons, names and typings datamined by Kaphotics, SciresM, Marty, smealum, Bond697, Slashmolder &amp;
+            Normmatt<br>
+            Pokémon is © of Nintendo,
+            <time datetime="1995">1995</time>
+            -
+            <time datetime="2017">2017</time>
         </p>
     </footer>
 </article>

--- a/old_alola_dex.html
+++ b/old_alola_dex.html
@@ -12,9 +12,9 @@
     </style>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script>
-        $(window).on('load', function () {
-            $("#loader").fadeOut("slow");
-        });
+      $(window).on('load', function () {
+        $("#loader").fadeOut("slow");
+      });
     </script>
 </head>
 
@@ -86,237 +86,289 @@
             <table id="team-weaknesses">
                 <caption>This Team Is Weak Against</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
             <table id="team-immunities">
                 <caption>This Team Is Immune To</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
             <table id="team-resistances">
                 <caption>This Team Resists</caption>
                 <tbody>
-                    <tr class="type normal">
-                        <th>Normal</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type grass">
-                        <th>Grass</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fire">
-                        <th>Fire</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type water">
-                        <th>Water</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fighting">
-                        <th>Fighting</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type flying">
-                        <th>Flying</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type poison">
-                        <th>Poison</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ground">
-                        <th>Ground</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type rock">
-                        <th>Rock</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type bug">
-                        <th>Bug</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ghost">
-                        <th>Ghost</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type electric">
-                        <th>Electric</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type psychic">
-                        <th>Psychic</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type ice">
-                        <th>Ice</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dragon">
-                        <th>Dragon</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type dark">
-                        <th>Dark</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type steel">
-                        <th>Steel</th>
-                        <td>0</td>
-                    </tr><!--
-                    --><tr class="type fairy">
-                        <th>Fairy</th>
-                        <td>0</td>
-                    </tr>
+                <tr class="type normal">
+                    <th>Normal</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type grass">
+                    <th>Grass</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fire">
+                    <th>Fire</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type water">
+                    <th>Water</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fighting">
+                    <th>Fighting</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type flying">
+                    <th>Flying</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type poison">
+                    <th>Poison</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ground">
+                    <th>Ground</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type rock">
+                    <th>Rock</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type bug">
+                    <th>Bug</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ghost">
+                    <th>Ghost</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type electric">
+                    <th>Electric</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type psychic">
+                    <th>Psychic</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type ice">
+                    <th>Ice</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dragon">
+                    <th>Dragon</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type dark">
+                    <th>Dark</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type steel">
+                    <th>Steel</th>
+                    <td>0</td>
+                </tr><!--
+                    -->
+                <tr class="type fairy">
+                    <th>Fairy</th>
+                    <td>0</td>
+                </tr>
                 </tbody>
             </table>
         </div>
         <div id="copy-url">
-            <p>Click the "Copy" button to copy your team's URL to your clipboard and share it with your friends and neighbors!</p>
+            <p>Click the "Copy" button to copy your team's URL to your clipboard and share it with your friends and
+                neighbors!</p>
             <input type="text" readonly><!--
             --><a data-clipboard-target="#copy-url input">Copy</a>
         </div>
@@ -325,31 +377,70 @@
         <h2>Your Options</h2>
         <div id="filters">
             <h3>Filters</h3><!--
-            --><div class="filter">
+            -->
+            <div class="filter">
                 <label for="island-filter">Island</label><!--
                 --><select id="island-filter" multiple>
-                    <option value="island1">Melemele</option>
-                    <option value="island2">Akala</option>
-                    <option value="island3">Ula'ula</option>
-                    <option value="island4">Poni</option>
-                    <option value="island0">Other</option>
-                </select>
+                <option value="island1">Melemele</option>
+                <option value="island2">Akala</option>
+                <option value="island3">Ula'ula</option>
+                <option value="island4">Poni</option>
+                <option value="island0">Other</option>
+            </select>
             </div><!--
-            --><div class="filter">
+            -->
+            <div class="filter">
                 <label for="gen-filter">Generation</label><!--
                 --><select id="gen-filter" multiple>
-                    <option value="gen1">Generation I</option>
-                    <option value="gen2">Generation II</option>
-                    <option value="gen3">Generation III</option>
-                    <option value="gen4">Generation IV</option>
-                    <option value="gen5">Generation V</option>
-                    <option value="gen6">Generation VI</option>
-                    <option value="gen7">Generation VII</option>
-                </select>
+                <option value="gen1">Generation I</option>
+                <option value="gen2">Generation II</option>
+                <option value="gen3">Generation III</option>
+                <option value="gen4">Generation IV</option>
+                <option value="gen5">Generation V</option>
+                <option value="gen6">Generation VI</option>
+                <option value="gen7">Generation VII</option>
+            </select>
             </div><!--
-            --><div class="filter">
+            -->
+            <div class="filter">
                 <label for="type-filter">Type</label><!--
                 --><select id="type-filter" multiple>
+                <option value="normal">Normal</option>
+                <option value="grass">Grass</option>
+                <option value="fire">Fire</option>
+                <option value="water">Water</option>
+                <option value="fighting">Fighting</option>
+                <option value="flying">Flying</option>
+                <option value="poison">Poison</option>
+                <option value="ground">Ground</option>
+                <option value="rock">Rock</option>
+                <option value="bug">Bug</option>
+                <option value="ghost">Ghost</option>
+                <option value="electric">Electric</option>
+                <option value="psychic">Psychic</option>
+                <option value="ice">Ice</option>
+                <option value="dragon">Dragon</option>
+                <option value="dark">Dark</option>
+                <option value="steel">Steel</option>
+                <option value="fairy">Fairy</option>
+            </select>
+            </div><!--
+            --><a href="#" class="button" title="Show more filters">+</a><!--
+            --><a href="#" class="button hidden" title="Hide extra filters">−</a><!--
+            -->
+            <div class="more">
+                <div class="filter hidden">
+                    <label for="version-filter">Version</label><!--
+                    --><select id="version-filter" multiple>
+                    <option value="sun">Sun</option>
+                    <option value="moon">Moon</option>
+                    <option value="both">Both</option>
+                </select>
+                </div><!--
+                -->
+                <div class="filter hidden">
+                    <label for="resistance-filter">Resists</label><!--
+                    --><select id="resistance-filter" multiple>
                     <option value="normal">Normal</option>
                     <option value="grass">Grass</option>
                     <option value="fire">Fire</option>
@@ -369,21 +460,19 @@
                     <option value="steel">Steel</option>
                     <option value="fairy">Fairy</option>
                 </select>
-            </div><!--
-            --><a href="#" class="button" title="Show more filters">+</a><!--
-            --><a href="#" class="button hidden" title="Hide extra filters">−</a><!--
-            --><div class="more">
-                <div class="filter hidden">
-                    <label for="version-filter">Version</label><!--
-                    --><select id="version-filter" multiple>
-                        <option value="sun">Sun</option>
-                        <option value="moon">Moon</option>
-                        <option value="both">Both</option>
-                    </select>
                 </div><!--
-                --><div class="filter hidden">
-                    <label for="resistance-filter">Resists</label><!--
-                    --><select id="resistance-filter" multiple>
+                -->
+                <div class="filter hidden">
+                    <label for="evolution-filter">Evolution</label><!--
+                    --><select id="evolution-filter" multiple>
+                    <option value="nfe">Not Fully Evolved</option>
+                    <option value="fe">Fully Evolved</option>
+                    <option value="mega">Mega Evolved</option>
+                </select>
+                </div>
+                <div class="filter hidden">
+                    <label for="exclude-type-filter">Exclude Type</label>
+                    <select id="exclude-type-filter" multiple>
                         <option value="normal">Normal</option>
                         <option value="grass">Grass</option>
                         <option value="fire">Fire</option>
@@ -403,17 +492,10 @@
                         <option value="steel">Steel</option>
                         <option value="fairy">Fairy</option>
                     </select>
-                </div><!--
-                --><div class="filter hidden">
-                    <label for="evolution-filter">Evolution</label><!--
-                    --><select id="evolution-filter" multiple>
-                        <option value="nfe">Not Fully Evolved</option>
-                        <option value="fe">Fully Evolved</option>
-                        <option value="mega">Mega Evolved</option>
-                    </select>
-                </div><!--
-                --><div class="filter hidden">
-                    <label for="search-bar">Search</label><input id="search-bar" type="search" placeholder="by Pokémon name">
+                </div>
+                <div class="filter hidden">
+                    <label for="search-bar">Search</label><input id="search-bar" type="search"
+                                                                 placeholder="by Pokémon name">
                 </div>
             </div>
         </div>
@@ -427,13 +509,21 @@
             <li class="gen7 island1 nfe water1"><a href="#" class="menu-sprite popplio">Popplio</a>
             <li class="gen7 island1 nfe water1"><a href="#" class="menu-sprite brionne">Brionne</a>
             <li class="gen7 island1 water1 fairy2"><a href="#" class="menu-sprite primarina">Primarina</a>
-            <li class="gen7 island1 island2 island3 island4 nfe normal1 flying2"><a href="#" class="menu-sprite pikipek">Pikipek</a>
-            <li class="gen7 island1 island2 island3 island4 nfe normal1 flying2"><a href="#" class="menu-sprite trumbeak">Trumbeak</a>
+            <li class="gen7 island1 island2 island3 island4 nfe normal1 flying2"><a href="#"
+                                                                                    class="menu-sprite pikipek">Pikipek</a>
+            <li class="gen7 island1 island2 island3 island4 nfe normal1 flying2"><a href="#"
+                                                                                    class="menu-sprite trumbeak">Trumbeak</a>
             <li class="gen7 island1 island2 island3 island4 normal1 flying2"><a href="#" class="menu-sprite toucannon">Toucannon</a>
-            <li class="gen7 island1 island2 island3 island4 nfe normal1"><a href="#" class="menu-sprite yungoos">Yungoos</a>
-            <li class="gen7 island1 island2 island3 island4 normal1"><a href="#" class="menu-sprite gumshoos">Gumshoos</a>
-            <li class="gen1 island1 island2 island3 island4 nfe dark1 normal2"><a href="#" class="menu-sprite rattata-alola">Alolan Rattata</a>
-            <li class="gen1 island1 island2 island3 island4 dark1 normal2"><a href="#" class="menu-sprite raticate-alola">Alolan Raticate</a>
+            <li class="gen7 island1 island2 island3 island4 nfe normal1"><a href="#"
+                                                                            class="menu-sprite yungoos">Yungoos</a>
+            <li class="gen7 island1 island2 island3 island4 normal1"><a href="#"
+                                                                        class="menu-sprite gumshoos">Gumshoos</a>
+            <li class="gen1 island1 island2 island3 island4 nfe dark1 normal2"><a href="#"
+                                                                                  class="menu-sprite rattata-alola">Alolan
+                Rattata</a>
+            <li class="gen1 island1 island2 island3 island4 dark1 normal2"><a href="#"
+                                                                              class="menu-sprite raticate-alola">Alolan
+                Raticate</a>
             <li class="gen1 island1 island2 nfe bug1"><a href="#" class="menu-sprite caterpie">Caterpie</a>
             <li class="gen1 island1 island2 nfe bug1"><a href="#" class="menu-sprite metapod">Metapod</a>
             <li class="gen1 island1 island2 bug1 flying2"><a href="#" class="menu-sprite butterfree">Butterfree</a>
@@ -449,27 +539,34 @@
             <li class="gen7 island1 island2 island3 bug1 electric2 levitate"><a href="#" class="menu-sprite vikavolt">Vikavolt</a>
             <li class="gen4 island1 island2 nfe rock1"><a href="#" class="menu-sprite bonsly">Bonsly</a>
             <li class="gen2 island1 island2 rock1"><a href="#" class="menu-sprite sudowoodo">Sudowoodo</a>
-            <li class="gen4 island1 island2 island3 island4 nfe normal1"><a href="#" class="menu-sprite happiny">Happiny</a>
-            <li class="gen1 island1 island2 island3 island4 nfe normal1"><a href="#" class="menu-sprite chansey">Chansey</a>
+            <li class="gen4 island1 island2 island3 island4 nfe normal1"><a href="#"
+                                                                            class="menu-sprite happiny">Happiny</a>
+            <li class="gen1 island1 island2 island3 island4 nfe normal1"><a href="#"
+                                                                            class="menu-sprite chansey">Chansey</a>
             <li class="gen2 island1 island2 island3 island4 normal1"><a href="#" class="menu-sprite blissey">Blissey</a>
             <li class="gen4 island1 nfe normal1"><a href="#" class="menu-sprite munchlax">Munchlax</a>
             <li class="gen1 island1 normal1"><a href="#" class="menu-sprite snorlax">Snorlax</a>
             <li class="gen1 island1 island3 nfe water1 psychic2"><a href="#" class="menu-sprite slowpoke">Slowpoke</a>
             <li class="gen1 island1 island3 water1 psychic2"><a href="#" class="menu-sprite slowbro">Slowbro</a>
-            <li class="gen1 island1 island3 water1 psychic2 filtered"><a href="#" class="menu-sprite slowbro-mega">Mega Slowbro</a>
+            <li class="gen1 island1 island3 water1 psychic2 filtered"><a href="#" class="menu-sprite slowbro-mega">Mega
+                Slowbro</a>
             <li class="gen2 island1 island3 water1 psychic2"><a href="#" class="menu-sprite slowking">Slowking</a>
-            <li class="gen3 island1 island3 island4 nfe water1 flying2"><a href="#" class="menu-sprite wingull">Wingull</a>
-            <li class="gen3 island1 island3 island4 water1 flying2"><a href="#" class="menu-sprite pelipper">Pelipper</a>
+            <li class="gen3 island1 island3 island4 nfe water1 flying2"><a href="#"
+                                                                           class="menu-sprite wingull">Wingull</a>
+            <li class="gen3 island1 island3 island4 water1 flying2"><a href="#"
+                                                                       class="menu-sprite pelipper">Pelipper</a>
             <li class="gen1 island1 nfe psychic1"><a href="#" class="menu-sprite abra">Abra</a>
             <li class="gen1 island1 nfe psychic1"><a href="#" class="menu-sprite kadabra">Kadabra</a>
             <li class="gen1 island1 psychic1"><a href="#" class="menu-sprite alakazam">Alakazam</a>
             <li class="gen1 island1 psychic1 filtered"><a href="#" class="menu-sprite alakazam-mega">Mega Alakazam</a>
             <li class="gen1 island1 island3 nfe dark1"><a href="#" class="menu-sprite meowth-alola">Alolan Meowth</a>
             <li class="gen1 island1 island3 dark1"><a href="#" class="menu-sprite persian-alola">Alolan Persian</a>
-            <li class="gen1 island1 island3 nfe electric1 steel2"><a href="#" class="menu-sprite magnemite">Magnemite</a>
+            <li class="gen1 island1 island3 nfe electric1 steel2"><a href="#"
+                                                                     class="menu-sprite magnemite">Magnemite</a>
             <li class="gen1 island1 island3 nfe electric1 steel2"><a href="#" class="menu-sprite magneton">Magneton</a>
             <li class="gen4 island1 island3 electric1 steel2"><a href="#" class="menu-sprite magnezone">Magnezone</a>
-            <li class="gen1 island1 island3 nfe poison1 dark2"><a href="#" class="menu-sprite grimer-alola">Alolan Grimer</a>
+            <li class="gen1 island1 island3 nfe poison1 dark2"><a href="#" class="menu-sprite grimer-alola">Alolan
+                Grimer</a>
             <li class="gen1 island1 island3 poison1 dark2"><a href="#" class="menu-sprite muk-alola">Alolan Muk</a>
             <li class="gen1 island1 nfe fire1"><a href="#" class="menu-sprite growlithe">Growlithe</a>
             <li class="gen1 island1 fire1"><a href="#" class="menu-sprite arcanine">Arcanine</a>
@@ -479,11 +576,15 @@
             <li class="gen3 island1 island4 fighting1"><a href="#" class="menu-sprite hariyama">Hariyama</a>
             <li class="gen2 island1 normal1"><a href="#" class="menu-sprite smeargle">Smeargle</a>
             <li class="gen7 island1 island2 island3 island4 nfe fighting1"><a href="#" class="menu-sprite crabrawler">Crabrawler</a>
-            <li class="gen7 island1 island2 island3 island4 fighting1 ice2"><a href="#" class="menu-sprite crabominable">Crabominable</a>
+            <li class="gen7 island1 island2 island3 island4 fighting1 ice2"><a href="#"
+                                                                               class="menu-sprite crabominable">Crabominable</a>
             <li class="gen1 island1 island2 island3 nfe ghost1 poison2 levitate"><a href="#" class="menu-sprite gastly">Gastly</a>
-            <li class="gen1 island1 island2 island3 nfe ghost1 poison2 levitate"><a href="#" class="menu-sprite haunter">Haunter</a>
+            <li class="gen1 island1 island2 island3 nfe ghost1 poison2 levitate"><a href="#"
+                                                                                    class="menu-sprite haunter">Haunter</a>
             <li class="gen1 island1 island2 island3 ghost1 poison2"><a href="#" class="menu-sprite gengar">Gengar</a>
-            <li class="gen1 island1 island2 island3 ghost1 poison2 filtered"><a href="#" class="menu-sprite gengar-mega">Mega Gengar</a>
+            <li class="gen1 island1 island2 island3 ghost1 poison2 filtered"><a href="#"
+                                                                                class="menu-sprite gengar-mega">Mega
+                Gengar</a>
             <li class="gen4 island1 nfe ghost1 flying2"><a href="#" class="menu-sprite drifloon">Drifloon</a>
             <li class="gen4 island1 ghost1 flying2"><a href="#" class="menu-sprite drifblim">Drifblim</a>
             <li class="gen2 island1 nfe ghost1 levitate"><a href="#" class="menu-sprite misdreavus">Misdreavus</a>
@@ -491,8 +592,12 @@
             <li class="gen1 island1 island2 island3 island4 nfe poison1 flying2"><a href="#" class="menu-sprite zubat">Zubat</a>
             <li class="gen1 island1 island2 island3 island4 nfe poison1 flying2"><a href="#" class="menu-sprite golbat">Golbat</a>
             <li class="gen2 island1 island2 island3 island4 poison1 flying2"><a href="#" class="menu-sprite crobat">Crobat</a>
-            <li class="gen1 island1 island2 island3 island4 nfe ground1 steel2"><a href="#" class="menu-sprite diglett-alola">Alolan Diglett</a>
-            <li class="gen1 island1 island2 island3 island4 ground1 steel2"><a href="#" class="menu-sprite dugtrio-alola">Alolan Dugtrio</a>
+            <li class="gen1 island1 island2 island3 island4 nfe ground1 steel2"><a href="#"
+                                                                                   class="menu-sprite diglett-alola">Alolan
+                Diglett</a>
+            <li class="gen1 island1 island2 island3 island4 ground1 steel2"><a href="#"
+                                                                               class="menu-sprite dugtrio-alola">Alolan
+                Dugtrio</a>
             <li class="gen1 island1 nfe normal1 island3 flying2"><a href="#" class="menu-sprite spearow">Spearow</a>
             <li class="gen1 island1 normal1 island3 flying2"><a href="#" class="menu-sprite fearow">Fearow</a>
             <li class="gen5 island1 island4 sun nfe normal1 flying2"><a href="#" class="menu-sprite rufflet">Rufflet</a>
@@ -506,19 +611,24 @@
             <li class="gen7 island2 psychic1 flying2"><a href="#" class="menu-sprite oricorio-pa-u">Oricorio</a>
             <li class="gen7 island3 fire1 flying2"><a href="#" class="menu-sprite oricorio-baile">Oricorio </a>
             <li class="gen7 island4 ghost1 flying2"><a href="#" class="menu-sprite oricorio-sensu">Oricorio</a>
-            <li class="gen7 island1 island3 island4 nfe bug1 fairy2"><a href="#" class="menu-sprite cutiefly">Cutiefly</a>
+            <li class="gen7 island1 island3 island4 nfe bug1 fairy2"><a href="#"
+                                                                        class="menu-sprite cutiefly">Cutiefly</a>
             <li class="gen7 island1 island3 island4 bug1 fairy2"><a href="#" class="menu-sprite ribombee">Ribombee</a>
             <li class="gen5 island1 island3 island4 moon nfe grass1"><a href="#" class="menu-sprite petilil">Petilil</a>
             <li class="gen5 island1 island3 island4 moon grass1"><a href="#" class="menu-sprite lilligant">Lilligant</a>
             <li class="gen5 island1 island3 island4 sun nfe grass1 fairy2"><a href="#" class="menu-sprite cottonee">Cottonee</a>
             <li class="gen5 island1 island3 island4 sun grass1 fairy2"><a href="#" class="menu-sprite whimsicott">Whimsicott</a>
-            <li class="gen1 island1 island2 island3 island4 nfe water1"><a href="#" class="menu-sprite psyduck">Psyduck</a>
+            <li class="gen1 island1 island2 island3 island4 nfe water1"><a href="#"
+                                                                           class="menu-sprite psyduck">Psyduck</a>
             <li class="gen1 island1 island2 island3 island4 water1"><a href="#" class="menu-sprite golduck">Golduck</a>
             <li class="gen1 island1 island2 island3 island4 nfe water1"><a href="#" class="menu-sprite magikarp">Magikarp</a>
             <li class="gen1 island1 island2 island3 island4 water1 flying2"><a href="#" class="menu-sprite gyarados">Gyarados</a>
-            <li class="gen1 island1 island2 island3 island4 water1 dark2 filtered"><a href="#" class="menu-sprite gyarados-mega">Mega Gyarados</a>
+            <li class="gen1 island1 island2 island3 island4 water1 dark2 filtered"><a href="#"
+                                                                                      class="menu-sprite gyarados-mega">Mega
+                Gyarados</a>
             <li class="gen3 island1 island2 island4 nfe water1 ground2"><a href="#" class="menu-sprite barboach">Barboach</a>
-            <li class="gen3 island1 island2 island4 water1 ground2"><a href="#" class="menu-sprite whiscash">Whiscash</a>
+            <li class="gen3 island1 island2 island4 water1 ground2"><a href="#"
+                                                                       class="menu-sprite whiscash">Whiscash</a>
             <li class="gen1 island1 island4 nfe fighting1"><a href="#" class="menu-sprite machop">Machop</a>
             <li class="gen1 island1 island4 nfe fighting1"><a href="#" class="menu-sprite machoke">Machoke</a>
             <li class="gen1 island1 island4 fighting1"><a href="#" class="menu-sprite machamp">Machamp</a>
@@ -527,15 +637,19 @@
             <li class="gen5 island1 island4 rock1"><a href="#" class="menu-sprite gigalith">Gigalith</a>
             <li class="gen6 island1 island4 rock1 fairy2"><a href="#" class="menu-sprite carbink">Carbink</a>
             <li class="gen3 island1 island4 dark1 ghost2"><a href="#" class="menu-sprite sableye">Sableye</a>
-            <li class="gen3 island1 island4 dark1 ghost2 filtered"><a href="#" class="menu-sprite sableye-mega">Mega Sableye</a>
+            <li class="gen3 island1 island4 dark1 ghost2 filtered"><a href="#" class="menu-sprite sableye-mega">Mega
+                Sableye</a>
             <li class="gen7 island1 island4 nfe rock1"><a href="#" class="menu-sprite rockruff">Rockruff</a>
             <li class="gen7 island1 island4 sun rock1"><a href="#" class="menu-sprite lycanroc">Lycanroc</a>
             <li class="gen7 island1 island4 moon rock1"><a href="#" class="menu-sprite lycanroc-midnight">Lycanroc</a>
             <li class="gen3 island1 normal1"><a href="#" class="menu-sprite spinda">Spinda</a>
-            <li class="gen1 island1 island2 island3 island4 nfe water1 poison2"><a href="#" class="menu-sprite tentacool">Tentacool</a>
+            <li class="gen1 island1 island2 island3 island4 nfe water1 poison2"><a href="#"
+                                                                                   class="menu-sprite tentacool">Tentacool</a>
             <li class="gen1 island1 island2 island3 island4 water1 poison2"><a href="#" class="menu-sprite tentacruel">Tentacruel</a>
-            <li class="gen4 island1 island2 island3 island4 nfe water1"><a href="#" class="menu-sprite finneon">Finneon</a>
-            <li class="gen4 island1 island2 island3 island4 water1"><a href="#" class="menu-sprite lumineon">Lumineon</a>
+            <li class="gen4 island1 island2 island3 island4 nfe water1"><a href="#"
+                                                                           class="menu-sprite finneon">Finneon</a>
+            <li class="gen4 island1 island2 island3 island4 water1"><a href="#"
+                                                                       class="menu-sprite lumineon">Lumineon</a>
             <li class="gen7 island1 island2 island3 water1"><a href="#" class="menu-sprite wishiwashi">Wishiwashi</a>
             <li class="gen3 island1 island2 water1"><a href="#" class="menu-sprite luvdisc">Luvdisc</a>
             <li class="gen2 island1 island2 water1 rock2"><a href="#" class="menu-sprite corsola">Corsola</a>
@@ -546,7 +660,8 @@
             <li class="gen3 island1 nfe dragon1"><a href="#" class="menu-sprite bagon">Bagon</a>
             <li class="gen3 island1 nfe dragon1"><a href="#" class="menu-sprite shelgon">Shelgon</a>
             <li class="gen3 island1 dragon1 flying2"><a href="#" class="menu-sprite salamence">Salamence</a>
-            <li class="gen3 island1 dragon1 flying2 filtered"><a href="#" class="menu-sprite salamence-mega">Mega Salamence</a>
+            <li class="gen3 island1 dragon1 flying2 filtered"><a href="#" class="menu-sprite salamence-mega">Mega
+                Salamence</a>
             <li class="gen5 island2 nfe normal1"><a href="#" class="menu-sprite lillipup">Lillipup</a>
             <li class="gen5 island2 nfe normal1"><a href="#" class="menu-sprite herdier">Herdier</a>
             <li class="gen5 island2 normal1"><a href="#" class="menu-sprite stoutland">Stoutland</a>
@@ -593,7 +708,8 @@
             <li class="gen1 island2 nfe ground1"><a href="#" class="menu-sprite cubone">Cubone</a>
             <li class="gen1 island2 fire1 ghost2"><a href="#" class="menu-sprite marowak-alola">Alolan Marowak</a>
             <li class="gen1 island2 normal1"><a href="#" class="menu-sprite kangaskhan">Kangaskhan</a>
-            <li class="gen1 island2 normal1 filtered"><a href="#" class="menu-sprite kangaskhan-mega">Mega Kangaskhan</a>
+            <li class="gen1 island2 normal1 filtered"><a href="#" class="menu-sprite kangaskhan-mega">Mega
+                Kangaskhan</a>
             <li class="gen2 island2 nfe fire1"><a href="#" class="menu-sprite magby">Magby</a>
             <li class="gen1 island2 nfe fire1"><a href="#" class="menu-sprite magmar">Magmar</a>
             <li class="gen4 island2 fire1"><a href="#" class="menu-sprite magmortar">Magmortar</a>
@@ -604,7 +720,8 @@
             <li class="gen7 island2 grass1"><a href="#" class="menu-sprite tsareena">Tsareena</a>
             <li class="gen7 island2 fairy1"><a href="#" class="menu-sprite comfey">Comfey</a>
             <li class="gen1 island2 island4 bug1"><a href="#" class="menu-sprite pinsir">Pinsir</a>
-            <li class="gen1 island2 island4 bug1 flying2 filtered"><a href="#" class="menu-sprite pinsir-mega">Mega Pinsir</a>
+            <li class="gen1 island2 island4 bug1 flying2 filtered"><a href="#" class="menu-sprite pinsir-mega">Mega
+                Pinsir</a>
             <li class="gen7 island2 moon normal1 psychic2"><a href="#" class="menu-sprite oranguru">Oranguru</a>
             <li class="gen7 island2 sun fighting1"><a href="#" class="menu-sprite passimian">Passimian</a>
             <li class="gen6 island2 island3 island4 nfe dragon1"><a href="#" class="menu-sprite goomy">Goomy</a>
@@ -664,7 +781,8 @@
             <li class="gen3 island3 nfe steel1 psychic2"><a href="#" class="menu-sprite beldum">Beldum</a>
             <li class="gen3 island3 nfe steel1 psychic2"><a href="#" class="menu-sprite metang">Metang</a>
             <li class="gen3 island3 steel1 psychic2"><a href="#" class="menu-sprite metagross">Metagross</a>
-            <li class="gen3 island3 steel1 psychic2 filtered"><a href="#" class="menu-sprite metagross-mega">Mega Metagross</a>
+            <li class="gen3 island3 steel1 psychic2 filtered"><a href="#" class="menu-sprite metagross-mega">Mega
+                Metagross</a>
             <li class="gen1 island3 nfe normal1"><a href="#" class="menu-sprite porygon">Porygon</a>
             <li class="gen2 island3 nfe normal1"><a href="#" class="menu-sprite porygon2">Porygon2</a>
             <li class="gen4 island3 normal1"><a href="#" class="menu-sprite porygon-z">Porygon-Z</a>
@@ -677,8 +795,10 @@
             <li class="gen2 island3 nfe electric1"><a href="#" class="menu-sprite elekid">Elekid</a>
             <li class="gen1 island3 nfe electric1"><a href="#" class="menu-sprite electabuzz">Electabuzz</a>
             <li class="gen4 island3 electric1"><a href="#" class="menu-sprite electivire">Electivire</a>
-            <li class="gen1 island3 nfe rock1 electric2"><a href="#" class="menu-sprite geodude-alola">Alolan Geodude</a>
-            <li class="gen1 island3 nfe rock1 electric2"><a href="#" class="menu-sprite graveler-alola">Alolan Graveler</a>
+            <li class="gen1 island3 nfe rock1 electric2"><a href="#" class="menu-sprite geodude-alola">Alolan
+                Geodude</a>
+            <li class="gen1 island3 nfe rock1 electric2"><a href="#" class="menu-sprite graveler-alola">Alolan
+                Graveler</a>
             <li class="gen1 island3 rock1 electric2"><a href="#" class="menu-sprite golem-alola">Alolan Golem</a>
             <li class="gen5 island3 nfe ground1 dark2"><a href="#" class="menu-sprite sandile">Sandile</a>
             <li class="gen5 island3 nfe ground1 dark2"><a href="#" class="menu-sprite krokorok">Krokorok</a>
@@ -689,7 +809,8 @@
             <li class="gen4 island3 nfe dragon1 ground2"><a href="#" class="menu-sprite gible">Gible</a>
             <li class="gen4 island3 nfe dragon1 ground2"><a href="#" class="menu-sprite gabite">Gabite</a>
             <li class="gen4 island3 dragon1 ground2"><a href="#" class="menu-sprite garchomp">Garchomp</a>
-            <li class="gen4 island3 dragon1 ground2 filtered"><a href="#" class="menu-sprite garchomp-mega">Mega Garchomp</a>
+            <li class="gen4 island3 dragon1 ground2 filtered"><a href="#" class="menu-sprite garchomp-mega">Mega
+                Garchomp</a>
             <li class="gen6 island3 steel1 fairy2"><a href="#" class="menu-sprite klefki">Klefki</a>
             <li class="gen7 island3 ghost1 fairy2"><a href="#" class="menu-sprite mimikyu">Mimikyu</a>
             <li class="gen7 island3 water1 psychic2"><a href="#" class="menu-sprite bruxish">Bruxish</a>
@@ -702,10 +823,13 @@
             <li class="gen4 island3 ice1 ghost2"><a href="#" class="menu-sprite froslass">Froslass</a>
             <li class="gen2 island3 nfe dark1 ice2"><a href="#" class="menu-sprite sneasel">Sneasel</a>
             <li class="gen4 island3 dark1 ice2"><a href="#" class="menu-sprite weavile">Weavile</a>
-            <li class="gen1 island3 moon nfe ice1 steel2"><a href="#" class="menu-sprite sandshrew-alola">Alolan Sandshrew</a>
-            <li class="gen1 island3 moon ice1 steel2"><a href="#" class="menu-sprite sandslash-alola">Alolan Sandslash</a>
+            <li class="gen1 island3 moon nfe ice1 steel2"><a href="#" class="menu-sprite sandshrew-alola">Alolan
+                Sandshrew</a>
+            <li class="gen1 island3 moon ice1 steel2"><a href="#" class="menu-sprite sandslash-alola">Alolan
+                Sandslash</a>
             <li class="gen1 island3 sun nfe ice1"><a href="#" class="menu-sprite vulpix-alola">Alolan Vulpix</a>
-            <li class="gen1 island3 sun ice1 fairy2"><a href="#" class="menu-sprite ninetales-alola">Alolan Ninetales</a>
+            <li class="gen1 island3 sun ice1 fairy2"><a href="#" class="menu-sprite ninetales-alola">Alolan
+                Ninetales</a>
             <li class="gen5 island3 nfe ice1"><a href="#" class="menu-sprite vanillite">Vanillite</a>
             <li class="gen5 island3 nfe ice1"><a href="#" class="menu-sprite vanillish">Vanillish</a>
             <li class="gen5 island3 ice1"><a href="#" class="menu-sprite vanilluxe">Vanilluxe</a>
@@ -719,7 +843,8 @@
             <li class="gen7 island4 ghost1 grass2"><a href="#" class="menu-sprite dhelmise">Dhelmise</a>
             <li class="gen3 island4 nfe water1 dark2"><a href="#" class="menu-sprite carvanha">Carvanha</a>
             <li class="gen3 island4 water1 dark2"><a href="#" class="menu-sprite sharpedo">Sharpedo</a>
-            <li class="gen3 island4 water1 dark2 filtered"><a href="#" class="menu-sprite sharpedo-mega">Mega Sharpedo</a>
+            <li class="gen3 island4 water1 dark2 filtered"><a href="#" class="menu-sprite sharpedo-mega">Mega
+                Sharpedo</a>
             <li class="gen3 island4 nfe water1"><a href="#" class="menu-sprite wailmer">Wailmer</a>
             <li class="gen3 island4 water1"><a href="#" class="menu-sprite wailord">Wailord</a>
             <li class="gen1 island4 water1 ice2"><a href="#" class="menu-sprite lapras">Lapras</a>
@@ -736,12 +861,14 @@
             <li class="gen4 island4 dark1 flying2"><a href="#" class="menu-sprite honchkrow">Honchkrow</a>
             <li class="gen4 island4 nfe fighting1"><a href="#" class="menu-sprite riolu">Riolu</a>
             <li class="gen4 island4 fighting1 steel2"><a href="#" class="menu-sprite lucario">Lucario</a>
-            <li class="gen4 island4 fighting1 steel2 filtered"><a href="#" class="menu-sprite lucario-mega">Mega Lucario</a>
+            <li class="gen4 island4 fighting1 steel2 filtered"><a href="#" class="menu-sprite lucario-mega">Mega
+                Lucario</a>
             <li class="gen1 island4 nfe dragon1"><a href="#" class="menu-sprite dratini">Dratini</a>
             <li class="gen1 island4 nfe dragon1"><a href="#" class="menu-sprite dragonair">Dragonair</a>
             <li class="gen1 island4 dragon1 flying2"><a href="#" class="menu-sprite dragonite">Dragonite</a>
             <li class="gen1 island4 rock1 flying2"><a href="#" class="menu-sprite aerodactyl">Aerodactyl</a>
-            <li class="gen1 island4 rock1 flying2 filtered"><a href="#" class="menu-sprite aerodactyl-mega">Mega Aerodactyl</a>
+            <li class="gen1 island4 rock1 flying2 filtered"><a href="#" class="menu-sprite aerodactyl-mega">Mega
+                Aerodactyl</a>
             <li class="gen7 island1 electric1 fairy2"><a href="#" class="menu-sprite tapu-koko">Tapu Koko</a>
             <li class="gen7 island2 psychic1 fairy2"><a href="#" class="menu-sprite tapu-lele">Tapu Lele</a>
             <li class="gen7 island3 grass1 fairy2"><a href="#" class="menu-sprite tapu-bulu">Tapu Bulu</a>
@@ -851,14 +978,36 @@
         </ol>
     </section>
     <footer>
-        <p class="links">Looking for another dex? Check out the planners for the <a href="national_dex.html">National</a>, <a href="kalos_dex.html">Kalos</a>, <a href="hoenn_dex.html">Hoenn</a>, and <a href="/pokemon-team-planner/">New Alola</a> dexes.</p>
-        <p>Please report bugs or leave feedback in <a href="http://www.smogon.com/forums/threads/team-planner-for-pok%C3%A9mon-sun-moon.3585346/">this thread</a>.</p>
+        <p class="links">Looking for another dex? Check out the planners for the <a
+                href="national_dex.html">National</a>, <a href="kalos_dex.html">Kalos</a>, <a href="hoenn_dex.html">Hoenn</a>,
+            and <a href="/pokemon-team-planner/">New Alola</a> dexes.</p>
+        <p>Please report bugs or leave feedback in <a
+                href="http://www.smogon.com/forums/threads/team-planner-for-pok%C3%A9mon-sun-moon.3585346/">this
+            thread</a>.</p>
         <p>
-            © of <a href="http://twitter.com/richi3f">richi3f</a>, <time datetime="2016">2016</time>-<time datetime="2017">2017</time><br>
-            Bootstrap is © of Twitter, <time datetime="2016">2016</time><br>
-            <a href="http://davidstutz.github.io/bootstrap-multiselect/">Bootstrap Multiselect</a> is © of <a href="http://davidstutz.de/">David Stutz</a>, <time datetime="2012">2012</time>-<time datetime="2014">2014</time><br>
-            <a href="https://clipboardjs.com">Clipboard.js</a> is © of <a href="http://zenorocha.com">Zeno Rocha</a>, <time datetime="2015">2015</time>-<time datetime="2017">2017</time><br>
-            Pokémon is © of Nintendo, <time datetime="1995">1995</time>-<time datetime="2017">2017</time>
+            © of <a href="http://twitter.com/richi3f">richi3f</a>,
+            <time datetime="2016">2016</time>
+            -
+            <time datetime="2017">2017</time>
+            <br>
+            Bootstrap is © of Twitter,
+            <time datetime="2016">2016</time>
+            <br>
+            <a href="http://davidstutz.github.io/bootstrap-multiselect/">Bootstrap Multiselect</a> is © of <a
+                href="http://davidstutz.de/">David Stutz</a>,
+            <time datetime="2012">2012</time>
+            -
+            <time datetime="2014">2014</time>
+            <br>
+            <a href="https://clipboardjs.com">Clipboard.js</a> is © of <a href="http://zenorocha.com">Zeno Rocha</a>,
+            <time datetime="2015">2015</time>
+            -
+            <time datetime="2017">2017</time>
+            <br>
+            Pokémon is © of Nintendo,
+            <time datetime="1995">1995</time>
+            -
+            <time datetime="2017">2017</time>
         </p>
     </footer>
 </article>

--- a/static/script.js
+++ b/static/script.js
@@ -18,6 +18,13 @@ function filterPokemon(option, checked) {
         types[i++] = "." + type + "1";
         types[i++] = "." + type + "2";
     });
+    // get excluded types
+    var exclude = []; i = 0;
+    $("#exclude-type-filter option:selected").each(function() {
+        var type = $(this).val();
+        exclude[i++] = "." + type + "1";
+        exclude[i++] = "." + type + "2";
+    });
     // get selected resistances
     var resistances = []; i = 0;
     $("#resistance-filter option:selected").each(function() {
@@ -49,7 +56,8 @@ function filterPokemon(option, checked) {
            ($this.is(islands.join(',')) || !isAlolaDex) &&
            ($this.is(areas.join(',')) || !isKalosDex) &&
            ($this.is(types.join(',')) &&
-            $this.is(resistances.join(',')))) {
+             (!$this.is(exclude.join(',')) &&
+            $this.is(resistances.join(','))))) {
             // filter by version
             if (isAlolaDex) {
                 var includePkmnFromSun = $("#version-filter [value=sun]:selected").length > 0;
@@ -436,7 +444,7 @@ $(document).ready(function(){
         onSelectAll: filterPokemon
     });
     $("#search-bar").on("input", filterPokemon);
-    $("select").multiselect("selectAll", false);
+    $("select").not("#exclude-type-filter").multiselect("selectAll", false);
     if ($("#alola-dex").length > 0 || $("#new-alola-dex").length > 0) {
         $('#evolution-filter').multiselect('deselect', ['mega']);
     }

--- a/static/style.css
+++ b/static/style.css
@@ -2571,3 +2571,6 @@ footer{
   cursor:pointer;
   width: 5em;
 }
+#exclude-type-filter {
+    background-color: red;
+}


### PR DESCRIPTION
It lets you exclude certain types from the list. For instance right now if you deselect 'fire' but 'rock' is still selected, Magcargo, for instance, will still show up, whereas if you **exclude** 'fire' no fire types will show up, even as a secondary type.